### PR TITLE
ci: update dependabot configuration for NPMJS without secrets

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,20 +1,9 @@
-# To get started with Dependabot version updates, you'll need to specify which
-# package ecosystems to update and where the package manifests are located.
 # Please see the documentation for all configuration options:
 # https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
 
 version: 2
-registries:
-  npm-github:
-    token: "${{ secrets.THEME_NPM_REGISTRY_TOKEN }}"
-    type: npm-registry
-    url: "https://npm.pkg.github.com"
-
 updates:
-  -
-    directory: /
-    package-ecosystem: npm
+  - package-ecosystem: npm
+    directory: "/"
     schedule:
       interval: daily
-    registries:
-      - npm-github

--- a/.gitignore
+++ b/.gitignore
@@ -69,3 +69,5 @@ yarn-error.log
 # Yarn Integrity file
 .yarn-integrity
 .npmrc
+
+.yarn

--- a/.gitignore
+++ b/.gitignore
@@ -69,5 +69,3 @@ yarn-error.log
 # Yarn Integrity file
 .yarn-integrity
 .npmrc
-
-.yarn


### PR DESCRIPTION
Remove the authentication for Dependabot – all packages are now fully public.