### PR TITLE
chore: ignore .yarn directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -69,3 +69,5 @@ yarn-error.log
 # Yarn Integrity file
 .yarn-integrity
 .npmrc
+
+.yarn


### PR DESCRIPTION
... as we don't use it for the Docker deployment